### PR TITLE
Register admin tabs on SkinTemplateNavigation::Universal (MW 1.43)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -89,7 +89,7 @@
 	],
 	"Hooks": {
 		"LoadExtensionSchemaUpdates": "MediaWiki\\Extension\\Promoter\\PRDatabasePatcher::applyUpdates",
-		"SkinTemplateNavigation::SpecialPage": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoter::addNavigationTabs"
+		"SkinTemplateNavigation::Universal": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoter::addNavigationTabs"
 	},
 	"SpecialPages": {
 		"Promoter": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoter",


### PR DESCRIPTION
## Problem

Same MediaWiki 1.43 dead-hook regression found while auditing the in-house extensions alongside `PR kolzchut/mediawiki-extensions-MarkMajorChanges` (the MarkMajorChanges toolbar button).

`extension.json` registers Promoter's Special-page navigation tabs under the legacy **`SkinTemplateNavigation::SpecialPage`** hook, which MediaWiki core no longer fires in 1.43 (only `SkinTemplateNavigation::Universal` remains). The tabs on `Special:Promoter` (and related admin pages) are therefore silently dropped.

## Fix

Move the registration to `SkinTemplateNavigation::Universal`. `SpecialPromoter::addNavigationTabs()` already resolves the title alias against `$wgPromoterTabifyPages` and returns early for non-matching pages, so firing on every page (rather than only special pages) is safe and produces the same tabs where expected.

## Testing

- `extension.json` validated as JSON.
- Handler is unchanged; the early-return guard covers the wider firing scope.