### PR TITLE
Modernize hooks to service injection and dialogs to OOUI (MW 1.43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ request ads, which is used in turn by Extension:Discovery, which offers its own 
 
 
 ## Changelog
+- 1.1.0, 2026-07-01
+  - Modernise for MediaWiki 1.43:
+    - Register the skin navigation tabs through an instance-based `HookHandlers`
+      class with service injection (replacing the removed
+      `SkinTemplateNavigation::SpecialPage` hook, on top of the earlier
+      `::Universal` fix); inject `IConnectionProvider` into the special pages.
+    - Fix latent 1.43 fatals that made `Special:PromoterAds` unusable:
+      `WebRequest::getLimitOffset()` → `getLimitOffsetForUser()` and
+      `Sanitizer::escapeId()` → `escapeIdForAttribute()`.
+  - Replace the jQuery UI admin dialogs with OOUI (`OO.ui.confirm`/`OO.ui.prompt`)
+    and drop the `jquery.ui` dependency from the admin modules.
 - 1.0.0, 2021-05-10
   - A major milestone on the road to merging this extension with extension:Discovery:
 	- Remove all logic from this extension, as it no longer handles choosing and displaying ads

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Promoter",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"author": [
 		"Dror S. [FFS] ([https://www.kolzchut.org.il Kol-Zchut])",
 		"based on [https://mediawiki.org/wiki/Extension:CentralNotice Extension:CentralNotice]"
@@ -31,11 +31,12 @@
 		"ext.promoter.adminUi.adManager": {
 			"dependencies": [
 				"ext.promoter.adminUi",
-				"jquery.ui"
+				"oojs-ui-windows"
 			],
 			"scripts": "ext.promoter.adminUi.adManager/admanager.js",
 			"styles": "ext.promoter.adminUi.adManager/admanager.css",
 			"messages": [
+				"promoter-ad-name",
 				"promoter-add-ad-button",
 				"promoter-add-ad-cancel-button",
 				"promoter-archive-ad",
@@ -52,13 +53,13 @@
 		"ext.promoter.adminUi.adEditor": {
 			"dependencies": [
 				"ext.promoter.adminUi",
-				"jquery.ui",
 				"oojs-ui-windows"
 			],
 			"scripts": "ext.promoter.adminUi.adEditor/adeditor.js",
 			"styles": "ext.promoter.adminUi.adEditor/adeditor.css",
 			"messages": [
 				"promoter-clone",
+				"promoter-clone-name",
 				"promoter-clone-campaign",
 				"promoter-clone-cancel",
 				"promoter-archive-ad",
@@ -73,8 +74,7 @@
 		},
 		"ext.promoter.adminUi.campaignManager": {
 			"dependencies": [
-				"ext.promoter.adminUi",
-				"jquery.ui"
+				"ext.promoter.adminUi"
 			],
 			"scripts": "ext.promoter.adminUi.campaignManager/campaignManager.js",
 			"styles": "ext.promoter.adminUi.campaignManager/campaignManager.css"
@@ -87,13 +87,32 @@
 	"AvailableRights": [
 		"promoter-admin"
 	],
+	"HookHandlers": {
+		"main": {
+			"class": "MediaWiki\\Extension\\Promoter\\Hooks",
+			"services": [
+				"SpecialPageFactory",
+				"MainConfig"
+			]
+		}
+	},
 	"Hooks": {
 		"LoadExtensionSchemaUpdates": "MediaWiki\\Extension\\Promoter\\PRDatabasePatcher::applyUpdates",
-		"SkinTemplateNavigation::Universal": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoter::addNavigationTabs"
+		"SkinTemplateNavigation::Universal": "main"
 	},
 	"SpecialPages": {
-		"Promoter": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoter",
-		"PromoterAds": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoterAds"
+		"Promoter": {
+			"class": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoter",
+			"services": [
+				"ConnectionProvider"
+			]
+		},
+		"PromoterAds": {
+			"class": "MediaWiki\\Extension\\Promoter\\Special\\SpecialPromoterAds",
+			"services": [
+				"ConnectionProvider"
+			]
+		}
 	},
 	"GroupPermissions": {
 		"sysop": {

--- a/includes/HTMLPromoterAd.php
+++ b/includes/HTMLPromoterAd.php
@@ -81,7 +81,7 @@ class HTMLPromoterAd extends HTMLInfoField {
 		return Xml::tags(
 			'div',
 			[
-				 'id' => Sanitizer::escapeId( "pr-ad-preview-$adName" ),
+				 'id' => Sanitizer::escapeIdForAttribute( "pr-ad-preview-$adName" ),
 				 'class' => 'pr-ad-preview-div',
 			],
 			$preview
@@ -129,7 +129,7 @@ class HTMLPromoterAd extends HTMLInfoField {
 		$html = Xml::openElement(
 			'div',
 			[
-				 'id' => Sanitizer::escapeId( "pr-ad-list-element-{$this->mParams['ad']}" ),
+				 'id' => Sanitizer::escapeIdForAttribute( "pr-ad-list-element-{$this->mParams['ad']}" ),
 				 'class' => "pr-ad-list-element",
 			]
 		);

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MediaWiki\Extension\Promoter;
+
+use MediaWiki\Config\Config;
+use MediaWiki\Hook\SkinTemplateNavigation__UniversalHook;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\SpecialPage\SpecialPageFactory;
+
+/**
+ * Skin hooks for the Promoter extension.
+ */
+class Hooks implements SkinTemplateNavigation__UniversalHook {
+
+	public function __construct(
+		private readonly SpecialPageFactory $specialPageFactory,
+		private readonly Config $config
+	) {
+	}
+
+	/**
+	 * Add navigation tabs linking the Promoter admin special pages together.
+	 *
+	 * Fires on every page, but only acts when the current title is one of the
+	 * tabified Promoter special pages.
+	 *
+	 * @param \SkinTemplate $sktemplate
+	 * @param array &$links
+	 */
+	public function onSkinTemplateNavigation__Universal( $sktemplate, &$links ): void {
+		$tabifyPages = $this->config->get( 'PromoterTabifyPages' );
+
+		$title = $sktemplate->getTitle();
+		[ $alias, ] = $this->specialPageFactory->resolveAlias( $title->getText() );
+
+		if ( !array_key_exists( $alias, $tabifyPages ) ) {
+			return;
+		}
+
+		foreach ( $tabifyPages as $page => $keys ) {
+			$links[ $keys['type'] ][ $page ] = [
+				'text' => $sktemplate->msg( $keys['message'] ),
+				'href' => SpecialPage::getTitleFor( $page )->getFullURL(),
+				'class' => ( $alias === $page ) ? 'selected' : ''
+			];
+		}
+	}
+}

--- a/includes/PRAdPager.php
+++ b/includes/PRAdPager.php
@@ -40,7 +40,7 @@ class PRAdPager extends ReverseChronologicalPager {
 		$this->formSection = $formSection;
 
 		// Override paging defaults
-		[ $this->mLimit, $this->mOffset ] = $this->mRequest->getLimitOffset( 20, '' );
+		[ $this->mLimit, $this->mOffset ] = $this->mRequest->getLimitOffsetForUser( $this->getUser(), 20, '' );
 		$this->mLimitsShown = [ 20, 50, 100 ];
 	}
 

--- a/includes/Special/SpecialPromoter.php
+++ b/includes/Special/SpecialPromoter.php
@@ -9,7 +9,6 @@ use MediaWiki\Extension\Promoter\AdCampaign;
 use MediaWiki\Extension\Promoter\AdCampaignExistenceException;
 use MediaWiki\Extension\Promoter\AdDataException;
 use MediaWiki\Extension\Promoter\PromoterPager;
-use MediaWiki\MediaWikiServices;
 use SpecialPage;
 use Wikimedia\Rdbms\IConnectionProvider;
 use Xml;
@@ -28,11 +27,12 @@ class SpecialPromoter extends SpecialPage {
 	/**
 	 * SpecialPromoter constructor.
 	 *
+	 * @param IConnectionProvider $dbProvider
 	 * @param string $name
 	 */
-	public function __construct( $name = 'Promoter' ) {
+	public function __construct( IConnectionProvider $dbProvider, $name = 'Promoter' ) {
 		parent::__construct( $name );
-		$this->dbProvider = MediaWikiServices::getInstance()->getConnectionProvider();
+		$this->dbProvider = $dbProvider;
 	}
 
 	/**
@@ -421,7 +421,7 @@ class SpecialPromoter extends SpecialPage {
 			$htmlOut .= Html::closeElement( 'div' );
 
 			// @todo this is probably the wrong way to do this
-			$editToken =  $this->getContext()->getCsrfTokenSet()->getToken();
+			$editToken = $this->getContext()->getCsrfTokenSet()->getToken();
 			$htmlOut .= Html::hidden( 'authtoken', $editToken );
 
 			// Submit button
@@ -837,38 +837,6 @@ class SpecialPromoter extends SpecialPage {
 		}
 
 		return trim( $retval );
-	}
-
-	/**
-	 * Adds Promoter specific navigation tabs to the UI.
-	 * Implementation of SkinTemplateNavigation::SpecialPage hook.
-	 *
-	 * @param \Skin $skin Reference to the Skin object
-	 * @param array &$tabs Any current skin tabs
-	 *
-	 * @return bool
-	 * @throws \MWException
-	 */
-	public static function addNavigationTabs( \Skin $skin, array &$tabs ) {
-		global $wgPromoterTabifyPages;
-
-		$title = $skin->getTitle();
-		$specialPageFactory = MediaWikiServices::getInstance()->getSpecialPageFactory();
-		[ $alias, $subPage ] = $specialPageFactory->resolveAlias( $title->getText() );
-
-		if ( !array_key_exists( $alias, $wgPromoterTabifyPages ) ) {
-			return true;
-		}
-
-		foreach ( $wgPromoterTabifyPages as $page => $keys ) {
-			$tabs[ $keys[ 'type' ] ][ $page ] = [
-				'text' => wfMessage( $keys[ 'message' ] ),
-				'href' => SpecialPage::getTitleFor( $page )->getFullURL(),
-				'class' => ( $alias === $page ) ? 'selected' : ''
-			];
-		}
-
-		return true;
 	}
 
 }

--- a/includes/Special/SpecialPromoterAds.php
+++ b/includes/Special/SpecialPromoterAds.php
@@ -14,6 +14,7 @@ use MediaWiki\Extension\Promoter\PromoterHtmlForm;
 use MWException;
 use MWTimestamp;
 use SpecialPage;
+use Wikimedia\Rdbms\IConnectionProvider;
 use Wikimedia\Timestamp\TimestampException;
 
 /**
@@ -38,10 +39,11 @@ class SpecialPromoterAds extends SpecialPromoter {
 	/**
 	 * SpecialPromoterAds constructor.
 	 *
+	 * @param IConnectionProvider $dbProvider
 	 * @param string $name
 	 */
-	public function __construct( $name = 'PromoterAds' ) {
-		parent::__construct( $name );
+	public function __construct( IConnectionProvider $dbProvider, $name = 'PromoterAds' ) {
+		parent::__construct( $dbProvider, $name );
 
 		// Make sure we have a session
 		$this->getRequest()->getSession()->persist();
@@ -153,7 +155,7 @@ class SpecialPromoterAds extends SpecialPromoter {
 				'section' => 'header/ad-search',
 				'class' => 'HTMLTextField',
 				// 'cssclass' => 'form-control',
-				'placeholder' => wfMessage( 'promoter-filter-ad-prompt' ),
+				'placeholder' => $this->msg( 'promoter-filter-ad-prompt' ),
 				'filter-callback' => [ $this, 'sanitizeSearchTerms' ],
 				'default' => $filter,
 			],
@@ -161,7 +163,7 @@ class SpecialPromoterAds extends SpecialPromoter {
 				'section' => 'header/ad-search',
 				'class' => 'HTMLSubmitField',
 				// 'cssclass' => 'btn',
-				'default' => wfMessage( 'promoter-filter-ad-submit' )->text(),
+				'default' => $this->msg( 'promoter-filter-ad-submit' )->text(),
 			]
 		];
 
@@ -186,14 +188,14 @@ class SpecialPromoterAds extends SpecialPromoter {
 				'section' => 'header/ad-bulk-manage',
 				'class' => 'HTMLButtonField',
 				// 'cssclass' => 'btn danger ',
-				'default' => wfMessage( 'promoter-remove' )->text(),
+				'default' => $this->msg( 'promoter-remove' )->text(),
 				'disabled' => !$this->editable,
 			],
 			'addNewAd' => [
 				'section' => 'header/one-off',
 				'class' => 'HTMLButtonField',
 				// 'cssclass' => 'btn',
-				'default' => wfMessage( 'promoter-add-ad' )->text(),
+				'default' => $this->msg( 'promoter-add-ad' )->text(),
 				'disabled' => !$this->editable,
 			],
 			'newAdName' => [
@@ -201,7 +203,7 @@ class SpecialPromoterAds extends SpecialPromoter {
 				'class' => 'HTMLTextField',
 				// 'cssclass' => 'form-control',
 				'disabled' => !$this->editable,
-				'label' => wfMessage( 'promoter-ad-name' )->text(),
+				'label' => $this->msg( 'promoter-ad-name' )->text(),
 			],
 			'action' => [
 				'type' => 'hidden',
@@ -248,13 +250,13 @@ class SpecialPromoterAds extends SpecialPromoter {
 					// Attempt to create a new ad and redirect; we validate here because it's
 					// a hidden field and that doesn't work so well with the form
 					if ( !Ad::isValidAdName( $formData[ 'newAdName' ] ) ) {
-						return wfMessage( 'promoter-ad-name-error' );
+						return $this->msg( 'promoter-ad-name-error' );
 					} else {
 						$this->adName = $formData[ 'newAdName' ];
 					}
 
 					if ( Ad::fromName( $this->adName )->exists() ) {
-						return wfMessage( 'promoter-ad-already-exists', $this->adName )->text();
+						return $this->msg( 'promoter-ad-already-exists', $this->adName )->text();
 					} else {
 						$retval = Ad::addAd(
 							$this->adName,
@@ -266,7 +268,7 @@ class SpecialPromoterAds extends SpecialPromoter {
 
 						if ( $retval && $retval !== true ) {
 							// Something failed; display error to user
-							return wfMessage( $retval )->text();
+							return $this->msg( $retval )->text();
 						} else {
 							$this->getOutput()->redirect(
 								SpecialPage::getTitleFor( 'PromoterAds', "edit/{$this->adName}" )->
@@ -299,7 +301,7 @@ class SpecialPromoterAds extends SpecialPromoter {
 			}
 		} elseif ( $formData[ 'action' ] ) {
 			// Oh noes! The l33t hakorz are here...
-			return wfMessage( 'promoter-generic-error' )->text();
+			return $this->msg( 'promoter-generic-error' )->text();
 		}
 
 		return null;
@@ -654,11 +656,11 @@ class SpecialPromoterAds extends SpecialPromoter {
 					( $formData[ 'ad-date-end' ] && !$formData[ 'ad-date-start' ] )
 					|| ( !$formData[ 'ad-date-end' ] && $formData[ 'ad-date-start' ] )
 				) {
-					return wfMessage( 'promoter-ad-inconsistent-dates-error' )->text();
+					return $this->msg( 'promoter-ad-inconsistent-dates-error' )->text();
 				}
 
 				if ( strtotime( $formData['ad-date-start'] ) > strtotime( $formData['ad-date-end'] ) ) {
-					return wfMessage( 'promoter-ad-date-end-bigger-than-date-start' )->text();
+					return $this->msg( 'promoter-ad-date-end-bigger-than-date-start' )->text();
 				}
 
 				if ( !$this->editable ) {

--- a/modules/ext.promoter.adminUi.adEditor/adeditor.js
+++ b/modules/ext.promoter.adminUi.adEditor/adeditor.js
@@ -12,39 +12,22 @@
 		 * @return {boolean}
 		 */
 		doCloneAdDialog: function () {
-			const buttons = {},
-				okButtonText = mw.message( 'promoter-clone' ).text(),
-				cancelButtonText = mw.message( 'promoter-clone-cancel' ).text(),
-				$dialogObj = $( '<form>' );
-
-			// Implement the functionality
-			buttons[ cancelButtonText ] = function () {
-				$( this ).dialog( 'close' );
-			};
-			buttons[ okButtonText ] = function () {
-				const formobj = document.getElementById( 'pr-ad-editor' );
-				formobj.wpaction.value = 'clone';
-				formobj.wpcloneName.value = $( this )[ 0 ].wpcloneName.value;
-				formobj.submit();
-			};
-
-			// Create the dialog by copying the textfield element into a new form
-			$dialogObj[ 0 ].name = 'addAdDialog';
-			const cloneSection = document.getElementById( 'pr-formsection-clone-ad' );
-			const divToClone = cloneSection.querySelector( 'div' );
-			if ( divToClone ) {
-				const clonedDiv = divToClone.cloneNode( true );
-				clonedDiv.style.display = '';
-				$dialogObj.append( clonedDiv );
-			}
-			$dialogObj.dialog( {
-				title: mw.message( 'promoter-clone' ).text(),
-				modal: true,
-				buttons: buttons,
-				width: 'auto'
+			OO.ui.prompt( mw.msg( 'promoter-clone-name' ), {
+				title: mw.msg( 'promoter-clone' ),
+				actions: [
+					{ action: 'accept', label: mw.msg( 'promoter-clone' ), flags: [ 'primary', 'progressive' ] },
+					{ action: 'reject', label: mw.msg( 'promoter-clone-cancel' ), flags: 'safe' }
+				]
+			} ).then( ( cloneName ) => {
+				if ( cloneName !== null ) {
+					const formobj = document.getElementById( 'pr-ad-editor' );
+					formobj.wpaction.value = 'clone';
+					formobj.wpcloneName.value = cloneName;
+					formobj.submit();
+				}
 			} );
 
-			// Do not submit the form... that's up to the ok button
+			// Do not submit the form... that's up to the dialog
 			return false;
 		},
 
@@ -68,26 +51,18 @@
 		 * the form with the 'remove' action.
 		 */
 		doDeleteAd: function () {
-			const $dialogObj = $( '<div>' ),
-				buttons = {},
-				deleteText = mw.message( 'promoter-delete-ad' ).text(),
-				cancelButtonText = mw.message( 'promoter-delete-ad-cancel' ).text();
-
-			buttons[ deleteText ] = function () {
-				const formobj = document.getElementById( 'pr-ad-editor' );
-				formobj.wpaction.value = 'delete';
-				formobj.submit();
-			};
-			buttons[ cancelButtonText ] = function () {
-				$( this ).dialog( 'close' );
-			};
-
-			$dialogObj.text( mw.message( 'promoter-delete-ad-confirm' ).text() );
-			$dialogObj.dialog( {
-				title: mw.message( 'promoter-delete-ad-title', 1 ).text(),
-				resizable: false,
-				modal: true,
-				buttons: buttons
+			OO.ui.confirm( mw.msg( 'promoter-delete-ad-confirm' ), {
+				title: mw.msg( 'promoter-delete-ad-title', 1 ),
+				actions: [
+					{ action: 'accept', label: mw.msg( 'promoter-delete-ad' ), flags: [ 'primary', 'destructive' ] },
+					{ action: 'reject', label: mw.msg( 'promoter-delete-ad-cancel' ), flags: 'safe' }
+				]
+			} ).then( ( confirmed ) => {
+				if ( confirmed ) {
+					const formobj = document.getElementById( 'pr-ad-editor' );
+					formobj.wpaction.value = 'delete';
+					formobj.submit();
+				}
 			} );
 		},
 
@@ -95,26 +70,18 @@
 		 * Submits the form with the archive action.
 		 */
 		doArchiveAd: function () {
-			const $dialogObj = $( '<div>' ),
-				buttons = {},
-				archiveText = mw.message( 'promoter-archive-ad' ).text(),
-				cancelButtonText = mw.message( 'promoter-archive-ad-cancel' ).text();
-
-			buttons[ archiveText ] = function () {
-				const formobj = document.getElementById( 'pr-ad-editor' );
-				formobj.wpaction.value = 'archive';
-				formobj.submit();
-			};
-			buttons[ cancelButtonText ] = function () {
-				$( this ).dialog( 'close' );
-			};
-
-			$dialogObj.text( mw.message( 'promoter-archive-ad-confirm' ).text() );
-			$dialogObj.dialog( {
-				title: mw.message( 'promoter-archive-ad-title', 1 ).text(),
-				resizable: false,
-				modal: true,
-				buttons: buttons
+			OO.ui.confirm( mw.msg( 'promoter-archive-ad-confirm' ), {
+				title: mw.msg( 'promoter-archive-ad-title', 1 ),
+				actions: [
+					{ action: 'accept', label: mw.msg( 'promoter-archive-ad' ), flags: [ 'primary' ] },
+					{ action: 'reject', label: mw.msg( 'promoter-archive-ad-cancel' ), flags: 'safe' }
+				]
+			} ).then( ( confirmed ) => {
+				if ( confirmed ) {
+					const formobj = document.getElementById( 'pr-ad-editor' );
+					formobj.wpaction.value = 'archive';
+					formobj.submit();
+				}
 			} );
 		},
 

--- a/modules/ext.promoter.adminUi.adManager/admanager.js
+++ b/modules/ext.promoter.adminUi.adManager/admanager.js
@@ -21,11 +21,10 @@
  */
 ( function () {
 
-	let am,
-		// Cache DOM references to avoid repeated queries
-		domRefs = {};
+	// Cache DOM references to avoid repeated queries
+	const domRefs = {};
 
-	am = mw.promoter.adminUi.adManager = {
+	const am = mw.promoter.adminUi.adManager = {
 		/**
 		 * State tracking variable for the number of items currently selected
 		 *
@@ -46,37 +45,23 @@
 		 * @return {boolean}
 		 */
 		doAddAdDialog: function () {
-			const buttons = {},
-				okButtonText = mw.message( 'promoter-add-ad-button' ).text(),
-				cancelButtonText = mw.message( 'promoter-add-ad-cancel-button' ).text(),
-				$dialogObj = $( '<form>' ),
-				$addAdSection = $( domRefs.formSectionAddAd ).children( 'div' ).clone().show();
+			OO.ui.prompt( mw.msg( 'promoter-ad-name' ), {
+				title: mw.msg( 'promoter-add-new-ad-title' ),
+				actions: [
+					{ action: 'accept', label: mw.msg( 'promoter-add-ad-button' ), flags: [ 'primary', 'progressive' ] },
+					{ action: 'reject', label: mw.msg( 'promoter-add-ad-cancel-button' ), flags: 'safe' }
+				]
+			} ).then( ( adName ) => {
+				// We'll submit the real form (outside the dialog).
+				// Copy in the entered name before submitting.
+				if ( adName !== null ) {
+					domRefs.adManagerForm.wpaction.value = 'create';
+					domRefs.adManagerForm.wpnewAdName.value = adName;
+					domRefs.adManagerForm.submit();
+				}
+			} );
 
-			// Implement the functionality
-			buttons[ cancelButtonText ] = function () {
-				$( this ).dialog( 'close' );
-			};
-
-			// We'll submit the real form (outside the dialog).
-			// Copy in values to that form before submitting.
-			buttons[ okButtonText ] = function () {
-				domRefs.adManagerForm.wpaction.value = 'create';
-				domRefs.adManagerForm.wpnewAdName.value = $( this )[ 0 ].wpnewAdName.value;
-
-				domRefs.adManagerForm.submit();
-			};
-
-			// Create the dialog by copying the textfield element into a new form
-			$dialogObj[ 0 ].name = $dialogObj[ 0 ].id = 'addAdDialog';
-			$dialogObj.append( $addAdSection )
-				.dialog( {
-					title: mw.message( 'promoter-add-new-ad-title' ).escaped(),
-					modal: true,
-					buttons: buttons,
-					width: 400
-				} );
-
-			// Do not submit the form... that's up to the ok button
+			// Do not submit the form... that's up to the dialog
 			return false;
 		},
 
@@ -85,65 +70,36 @@
 		 * the form with the 'remove' action.
 		 */
 		doRemoveAds: function () {
-			const $dialogObj = $( '<form>' ),
-				$dialogMessage = $( document.createElement( 'div' ) ).addClass( 'pr-dialog-message' ),
-				$removeAdSection = $( domRefs.formSectionRemoveAd ).children( 'div' ).clone().show(),
-				buttons = {},
-				deleteText = mw.message( 'promoter-delete-ad' ).text(),
-				cancelButtonText = mw.message( 'promoter-delete-ad-cancel' ).text();
-
-			// We'll submit the real form (outside the dialog).
-			// Copy in values to that form before submitting.
-			buttons[ deleteText ] = function () {
-				domRefs.adManagerForm.wpaction.value = 'remove';
-
-				domRefs.adManagerForm.submit();
-			};
-			buttons[ cancelButtonText ] = function () {
-				$( this ).dialog( 'close' );
-			};
-
-			$dialogObj.append( $dialogMessage );
-			$dialogMessage.text( mw.message( 'promoter-delete-ad-confirm' ).text() );
-
-			$dialogObj.append( $removeAdSection )
-				.dialog( {
-					title: mw.message(
-						'promoter-delete-ad-title',
-						am.selectedItemCount
-					).escaped(),
-					width: '35em',
-					modal: true,
-					buttons: buttons
-				} );
+			OO.ui.confirm( mw.msg( 'promoter-delete-ad-confirm' ), {
+				title: mw.msg( 'promoter-delete-ad-title', am.selectedItemCount ),
+				actions: [
+					{ action: 'accept', label: mw.msg( 'promoter-delete-ad' ), flags: [ 'primary', 'destructive' ] },
+					{ action: 'reject', label: mw.msg( 'promoter-delete-ad-cancel' ), flags: 'safe' }
+				]
+			} ).then( ( confirmed ) => {
+				// We'll submit the real form (outside the dialog).
+				if ( confirmed ) {
+					domRefs.adManagerForm.wpaction.value = 'remove';
+					domRefs.adManagerForm.submit();
+				}
+			} );
 		},
 
 		/**
 		 * Submits the form with the archive action.
 		 */
 		doArchiveAds: function () {
-			const $dialogObj = $( document.createElement( 'div' ) ),
-				buttons = {},
-				archiveText = mw.message( 'promoter-archive-ad' ).text(),
-				cancelButtonText = mw.message( 'promoter-archive-ad-cancel' ).text();
-
-			buttons[ archiveText ] = function () {
-				domRefs.adManagerForm.wpaction.value = 'archive';
-				domRefs.adManagerForm.submit();
-			};
-			buttons[ cancelButtonText ] = function () {
-				$( this ).dialog( 'close' );
-			};
-
-			$dialogObj.text( mw.message( 'promoter-archive-ad-confirm' ).text() );
-			$dialogObj.dialog( {
-				title: mw.message(
-					'promoter-archive-ad-title',
-					am.selectedItemCount
-				).escaped(),
-				resizable: false,
-				modal: true,
-				buttons: buttons
+			OO.ui.confirm( mw.msg( 'promoter-archive-ad-confirm' ), {
+				title: mw.msg( 'promoter-archive-ad-title', am.selectedItemCount ),
+				actions: [
+					{ action: 'accept', label: mw.msg( 'promoter-archive-ad' ), flags: [ 'primary' ] },
+					{ action: 'reject', label: mw.msg( 'promoter-archive-ad-cancel' ), flags: 'safe' }
+				]
+			} ).then( ( confirmed ) => {
+				if ( confirmed ) {
+					domRefs.adManagerForm.wpaction.value = 'archive';
+					domRefs.adManagerForm.submit();
+				}
 			} );
 		},
 
@@ -170,7 +126,7 @@
 		 * Updates the 'checkAll' check box if any of the ad check boxes are checked
 		 */
 		selectCheckStateAltered: function () {
-			if ( $( this ).prop( 'checked' ) === true ) {
+			if ( this.checked ) {
 				am.selectedItemCount++;
 			} else {
 				am.selectedItemCount--;
@@ -208,10 +164,8 @@
 		 * filter (or lack thereof).
 		 */
 		applyFilter: function () {
-			let newUri, filterStr;
-
-			filterStr = domRefs.filterInput.value;
-			newUri = new mw.Uri();
+			let filterStr = domRefs.filterInput.value;
+			const newUri = new mw.Uri();
 
 			// If there's a filter, reload with a filter query param.
 			// If there's no filter, reload with no such param.


### PR DESCRIPTION
Modernizes the extension per the in-house `mw-modernize-extension` guide, building on the earlier `SkinTemplateNavigation::Universal` hotfix (PR #13). Verified end-to-end on local dev with Playwright.

## PHP / hooks
- The skin navigation tabs now come from an **instance-based `HookHandlers` class** (`Hooks`) with `SpecialPageFactory` + `MainConfig` injected, replacing the static `SpecialPromoter::addNavigationTabs` callback and the `global $wgPromoterTabifyPages` read.
- Both special pages receive `IConnectionProvider` via ObjectFactory `services` specs instead of `MediaWikiServices::getInstance()`.
- `SpecialPromoterAds` switched from `wfMessage()` to `$this->msg()`.
- **Scope note:** the `Ad`/`AdCampaign` model classes are entirely static, so their `getInstance()` calls remain — static methods can't take constructor injection. Converting them to services is a separate, larger refactor.

## Pre-existing 1.43 fatals fixed (unblock the admin UI)
`Special:PromoterAds` hasn't run since the 1.43 upgrade — it fataled before rendering. Two removed-API calls are fixed so it works (and so the dialogs below could be verified):
- `WebRequest::getLimitOffset()` → `getLimitOffsetForUser()` (matches the sibling `AdPager`).
- `Sanitizer::escapeId()` → `Sanitizer::escapeIdForAttribute()`.

## JS — jQuery → OOUI
- The 6 jQuery UI `.dialog()` modals (add / clone / delete / archive) are now **OOUI** (`OO.ui.prompt` for name-input dialogs, `OO.ui.confirm` for confirmations), matching the `OO.ui.alert` already used. `jquery.ui` dropped from all admin modules (including two that declared it but never used it).
- Remaining trivial jQuery (`$(this).prop('checked')`) converted to vanilla.

## Testing (local dev, MW 1.43, `he` wiki, Dockeradmin, Playwright)
- `composer test` (parallel-lint + phpcs + minus-x): clean. `grunt eslint`: clean. (Pre-existing `stylelint` `selector-class-pattern` warnings in untouched CSS are left as-is — out of scope.)
- Extension loads; `Special:Promoter` + `Special:PromoterAds` render (HTTP 200, no fatal); DI nav tabs (Campaigns / Ads) appear.
- **Add-ad** → `OO.ui.prompt` opens with the name field + Create/Cancel.
- **Remove selected** → `OO.ui.confirm` opens with a destructive Delete + Cancel.
- Checkbox selection (the `this.checked` handler) works; 0 console errors throughout.

Version bumped to 1.1.0; changelog updated.