### PR TITLE
Add Playwright e2e tests for the admin dialogs

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/package-lock.json
+/playwright-report
+/test-results

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,47 @@
+# Promoter e2e tests
+
+Playwright end-to-end tests for the Promoter admin UI, focused on
+`Special:PromoterAds` and its OOUI dialogs. These lock in the MW 1.43
+modernization: that the ad-manager page renders (it previously fataled on the
+removed `WebRequest::getLimitOffset()` / `Sanitizer::escapeId()` APIs), and that
+the add/remove dialogs are OOUI (`OO.ui.prompt` / `OO.ui.confirm`) rather than
+the old jQuery UI `.dialog()` widgets.
+
+Assertions are **structural** (element ids, ARIA roles, OOUI CSS classes), not
+button text, so they are independent of the wiki's content language.
+
+## Setup
+
+```sh
+cd tests
+npm install
+npx playwright install chromium
+```
+
+## Run
+
+The dialogs require a logged-in user with the `promoter-admin` right, so the
+specs **skip** (they do not silently pass) unless credentials are supplied.
+
+```sh
+# against local dev (main site, he)
+MW_USERNAME=Dockeradmin MW_PASSWORD=<dev-password> \
+  npx playwright test
+
+# against another target
+MW_BASE_URL=https://staging-test.wikirights.org.il MW_SCRIPT_PATH=/w/he \
+MW_USERNAME=Dockeradmin MW_PASSWORD=<vault-password> \
+  npx playwright test
+```
+
+## Environment variables
+
+| Variable         | Default                 | Purpose                                  |
+|------------------|-------------------------|------------------------------------------|
+| `MW_BASE_URL`    | `http://localhost:8082` | Wiki base URL                            |
+| `MW_SCRIPT_PATH` | `/he`                   | Language/path prefix to the wiki         |
+| `MW_USERNAME`    | — (skips if unset)      | A `promoter-admin` user (e.g. Dockeradmin) |
+| `MW_PASSWORD`    | — (skips if unset)      | That user's password                     |
+
+The remove-ads spec selects an ad and opens the confirm dialog but always
+**cancels** — it never deletes anything.

--- a/tests/e2e/promoter-admin-dialogs.spec.ts
+++ b/tests/e2e/promoter-admin-dialogs.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { PromoterAdsPage } from '../pages/PromoterAdsPage';
+
+/**
+ * Promoter admin UI — Special:PromoterAds.
+ *
+ * Regression cover for the MW 1.43 modernization:
+ *   - The page renders at all (it previously fataled on removed 1.43 APIs
+ *     `WebRequest::getLimitOffset()` and `Sanitizer::escapeId()`).
+ *   - The admin dialogs are OOUI (`OO.ui.prompt` / `OO.ui.confirm`), not the
+ *     old jQuery UI `.dialog()` widgets — asserted structurally so the checks
+ *     don't depend on the wiki content language.
+ *
+ * The dialogs only render for a logged-in `promoter-admin` user, so the pack
+ * skips cleanly (never silently passes) when creds are absent.
+ *
+ * Run (against local dev):
+ *   MW_USERNAME=Dockeradmin MW_PASSWORD=... \
+ *     npx playwright test e2e/promoter-admin-dialogs.spec.ts
+ */
+
+const USERNAME = process.env.MW_USERNAME ?? '';
+const PASSWORD = process.env.MW_PASSWORD ?? '';
+
+test.describe('Promoter admin dialogs (Special:PromoterAds)', () => {
+  test.skip(
+    !USERNAME || !PASSWORD,
+    'Set MW_USERNAME / MW_PASSWORD (a promoter-admin user, e.g. Dockeradmin) to run these specs.'
+  );
+
+  let pageErrors: string[];
+
+  test.beforeEach(async ({ page }) => {
+    // Fail loudly on any uncaught page error (a broken module or a PHP-rendered
+    // fatal would surface here).
+    pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(String(err)));
+
+    const promoter = new PromoterAdsPage(page);
+    await promoter.login(USERNAME, PASSWORD);
+    await promoter.gotoAdManager();
+  });
+
+  test('ad-manager page renders without a 1.43 fatal', async ({ page }) => {
+    // The removed-API fatals produced a MediaWiki "Internal error" page.
+    await expect(page.locator('body')).not.toContainText('Internal error');
+    await expect(page.locator('body')).not.toContainText('Fatal error');
+    // The bulk-manage controls only exist once the ad list has rendered.
+    await expect(new PromoterAdsPage(page).addAdButton()).toBeVisible();
+    expect(pageErrors, `unexpected page errors: ${pageErrors.join('; ')}`).toHaveLength(0);
+  });
+
+  test('Add-ad opens an OOUI prompt dialog (name input)', async ({ page }) => {
+    const promoter = new PromoterAdsPage(page);
+
+    await promoter.addAdButton().click();
+
+    const dialog = promoter.openDialog();
+    await expect(dialog).toBeVisible();
+    // OO.ui.prompt = a dialog carrying a text input plus action buttons.
+    await expect(dialog.getByRole('textbox')).toBeVisible();
+    await expect(dialog.getByRole('button')).not.toHaveCount(0);
+
+    // Close without creating anything.
+    await promoter.dismissDialog();
+    expect(pageErrors, `unexpected page errors: ${pageErrors.join('; ')}`).toHaveLength(0);
+  });
+
+  test('Removing selected ads opens an OOUI confirm dialog (no text input) and cancels safely', async ({
+    page,
+  }) => {
+    const promoter = new PromoterAdsPage(page);
+
+    const firstCheckbox = promoter.adCheckboxes().first();
+    await expect(firstCheckbox, 'dev target has at least one ad to select').toBeVisible();
+    await firstCheckbox.check();
+
+    // Selecting an ad enables the remove button (the `this.checked` handler).
+    const removeButton = promoter.removeSelectedButton();
+    await expect(removeButton).toBeEnabled();
+    await removeButton.click();
+
+    const dialog = promoter.openDialog();
+    await expect(dialog).toBeVisible();
+    // OO.ui.confirm = a dialog with action buttons and NO text input.
+    await expect(dialog.getByRole('button')).not.toHaveCount(0);
+    await expect(dialog.getByRole('textbox')).toHaveCount(0);
+
+    // Cancel — must NOT delete the ad.
+    await promoter.dismissDialog();
+
+    // The ad list is unchanged (still on the ad manager, checkbox still present).
+    await expect(promoter.adCheckboxes().first()).toBeVisible();
+    expect(pageErrors, `unexpected page errors: ${pageErrors.join('; ')}`).toHaveLength(0);
+  });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "promoter-extension-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright e2e suite for the Promoter extension admin UI (campaign/ad management dialogs).",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "typecheck": "tsc --noEmit",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/pages/PromoterAdsPage.ts
+++ b/tests/pages/PromoterAdsPage.ts
@@ -1,0 +1,64 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Page object for Special:PromoterAds (the ad-manager admin UI) and its
+ * OOUI dialogs.
+ *
+ * Locators are deliberately structural (element ids, ARIA roles, OOUI CSS
+ * classes) rather than localized button text, so the suite is not tied to
+ * the wiki's content language.
+ */
+export class PromoterAdsPage {
+  readonly page: Page;
+  readonly scriptPath: string;
+
+  constructor(page: Page) {
+    this.page = page;
+    // e.g. "/he" — the language-prefixed path the dev/staging wikis serve under.
+    this.scriptPath = process.env.MW_SCRIPT_PATH || '/he';
+  }
+
+  /** Form-based login via Special:UserLogin (goes through ResourceLoader + redirect). */
+  async login(username: string, password: string): Promise<void> {
+    await this.page.goto(
+      `${this.scriptPath}/Special:UserLogin?returnto=Special:PromoterAds`
+    );
+    await this.page.getByRole('textbox').first().fill(username);
+    // The password field is the second textbox; target by its input type to be safe.
+    await this.page.locator('input[type="password"]').fill(password);
+    await this.page.locator('button[type="submit"], #wpLoginAttempt').first().click();
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async gotoAdManager(): Promise<void> {
+    await this.page.goto(`${this.scriptPath}/Special:PromoterAds`);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  addAdButton(): Locator {
+    return this.page.locator('#mw-input-wpaddNewAd');
+  }
+
+  removeSelectedButton(): Locator {
+    return this.page.locator('#mw-input-wpdeleteSelectedAds');
+  }
+
+  adCheckboxes(): Locator {
+    return this.page.locator('input.pr-adlist-check-applyto');
+  }
+
+  /** The currently-open OOUI dialog window (prompt or confirm). */
+  openDialog(): Locator {
+    return this.page.getByRole('dialog');
+  }
+
+  /**
+   * Dismiss any open OOUI dialog by clicking its safe (cancel) action — the
+   * reject action is flagged `safe` in both OO.ui.prompt and OO.ui.confirm, so
+   * this cancels without confirming and without depending on button text.
+   */
+  async dismissDialog(): Promise<void> {
+    await this.openDialog().locator('.oo-ui-flaggedElement-safe').first().click();
+    await expect(this.openDialog()).toBeHidden();
+  }
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for the Promoter extension admin-UI e2e tests.
+ *
+ * Run:
+ *   npx playwright test
+ *   npx playwright test --headed
+ *
+ * Environment variables:
+ *   MW_BASE_URL    - MediaWiki base URL (default: http://localhost:8082)
+ *   MW_SCRIPT_PATH - path prefix to index.php / the wiki (default: /he)
+ *   MW_USERNAME    - a user with the `promoter-admin` right (e.g. Dockeradmin)
+ *   MW_PASSWORD    - that user's password
+ *
+ * The admin dialogs only render for a logged-in `promoter-admin` user, so the
+ * specs skip cleanly (never silently pass) when MW_USERNAME/MW_PASSWORD are unset.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: ['**/*.spec.ts'],
+  timeout: 30000,
+  expect: { timeout: 7000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['list'],
+  ],
+
+  use: {
+    baseURL: process.env.MW_BASE_URL || 'http://localhost:8082',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'promoter-desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["e2e/**/*.ts", "pages/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
Adds a Playwright e2e suite under `tests/` (following the `skins/Cassandra/tests/` convention) that locks in the MW 1.43 admin-UI modernization (PR #14).

## Coverage (`Special:PromoterAds`)
- **Page renders without a 1.43 fatal** — regression guard for the removed-API fixes (`WebRequest::getLimitOffset()`, `Sanitizer::escapeId()`); asserts no "Internal error"/page errors and that the ad list rendered.
- **Add-ad → OOUI prompt** — clicking add opens a dialog with a text input + action buttons (`OO.ui.prompt`).
- **Remove selected → OOUI confirm** — selecting an ad enables the remove button (the `this.checked` handler) and opens a dialog with buttons and **no** text input (`OO.ui.confirm`); the spec always **cancels** — it never deletes.

## Design
- Assertions are **structural** (element ids, ARIA roles, `.oo-ui-*` classes), not button text, so they don't depend on the wiki content language.
- Specs **skip cleanly** (never silently pass) unless `MW_USERNAME`/`MW_PASSWORD` for a `promoter-admin` user are set — so anon/CI runs stay green.
- `pageerror` listener fails the test on any uncaught JS error.

## Verified
`npm install` + `npx playwright install chromium`, then `MW_USERNAME=Dockeradmin MW_PASSWORD=… npx playwright test` against local dev (MW 1.43): **3/3 passed**. `tsc --noEmit` clean. `node_modules`/reports/lockfile gitignored.

See `tests/README.md` for run instructions.